### PR TITLE
Polish producer and consumer examples

### DIFF
--- a/src/await_consumer_1n.rs
+++ b/src/await_consumer_1n.rs
@@ -1,124 +1,145 @@
 #[cfg(target_os = "linux")]
-use std::sync::atomic::{AtomicI32, AtomicUsize, AtomicU64};
+mod platform {
+    use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize};
 
-#[cfg(target_os = "linux")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(target_os = "linux")]
-use std::sync::Arc;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
-#[cfg(target_os = "linux")]
-use zenoh::Wait;
+    use zenoh::Wait;
 
-#[cfg(target_os = "linux")]
-use linux_futex::*;
+    use linux_futex::*;
 
-#[cfg(target_os = "linux")]
-// Shared data
-#[repr(C)]
-pub struct SharedData {
-    pub futex: Futex<Shared>, 
-    pub len: AtomicUsize,
-    pub sn: AtomicU64,
-    pub read_count: AtomicI32, // How many times the data can be consumed
-    pub sub_count: AtomicUsize, // Total number of consumers
-    pub data: [u8; 1024],
-}
+    // Shared data
+    #[repr(C)]
+    pub struct SharedData {
+        pub futex: Futex<Shared>,
+        pub len: AtomicUsize,
+        pub sn: AtomicU64,
+        pub read_count: AtomicI32, // How many times the data can be consumed
+        pub sub_count: AtomicUsize, // Total number of consumers
+        pub data: [u8; 1024],
+    }
 
-#[cfg(target_os = "linux")]
-fn main(){
-    let running = Arc::new(AtomicBool::new(true));
-    let r = running.clone();
-    
-    ctrlc::set_handler(move || {
-        println!("\nReceived Ctrl-C! Shutting down gracefully...");
-        r.store(false, Ordering::Release);
-    }).expect("Error setting Ctrl-C handler");
+    pub(crate) fn main() {
+        let running = Arc::new(AtomicBool::new(true));
+        let r = running.clone();
 
-    let z = zenoh::open(zenoh::Config::default())
-        .wait()
-        .expect("Failed to open Zenoh session");
+        ctrlc::set_handler(move || {
+            println!("\nReceived Ctrl-C! Shutting down gracefully...");
+            r.store(false, Ordering::Release);
+        })
+        .expect("Error setting Ctrl-C handler");
 
-    let rs = z
-        .get("shm/await/buffer_1n")
-        .wait()
-        .expect("Failed to get resource");
+        let z = zenoh::open(zenoh::Config::default())
+            .wait()
+            .expect("Failed to open Zenoh session");
 
-    if let Ok(mut r) = rs.recv() {
-        if let Ok(res) = r.result_mut() {
-            let buf = res.payload_mut();
+        let rs = z
+            .get("shm/await/buffer_1n")
+            .wait()
+            .expect("Failed to get resource");
 
-            let shm = if let Some(sm) = buf.as_shm() {
-                println!("Received SHM buffer");
-                sm.as_ptr() as *const SharedData
-            } else {
-                println!("Received non-SHM buffer");
-                std::ptr::null()
-            };
+        if let Ok(mut r) = rs.recv() {
+            if let Ok(res) = r.result_mut() {
+                let buf = res.payload_mut();
 
-            if shm.is_null() {
-                println!("Failed to get SHM pointer");
-                return;
-            }
+                let shm = if let Some(sm) = buf.as_shm() {
+                    println!("Received SHM buffer");
+                    sm.as_ptr() as *const SharedData
+                } else {
+                    println!("Received non-SHM buffer");
+                    std::ptr::null()
+                };
 
-            let shared_data: &SharedData = unsafe { &*shm };
-            
-            shared_data.sub_count.fetch_add(1, Ordering::AcqRel);
-            let mut read_count = -1;
-            let mut next_sn = 0u64;                        
-            
-            while running.load(Ordering::Acquire) {
-                log::debug!("Waiting for data to be produced -- futex: {}  / {}", shared_data.futex.value.load(Ordering::SeqCst), next_sn);
-                while shared_data.futex.value.load(Ordering::Acquire) == 0 {
-                    let _ = shared_data.futex.wait(0);                    
+                if shm.is_null() {
+                    println!("Failed to get SHM pointer");
+                    return;
                 }
-               
 
-                let len = shared_data.len.load(Ordering::Acquire);                
-                read_count = shared_data.read_count.load(Ordering::Acquire);
-                let sub_count = shared_data.sub_count.load(Ordering::Acquire);
-                log::debug!("Read count: {}, Sub count: {}, Length: {}", read_count, sub_count, len);
-                
-                // The only case in which this could happen is if another consumer was added. 
-                if read_count > 0 {
-                    // There is some data to read, if the SN is higher than what we read last time
-                    let sn = shared_data.sn.load(Ordering::Acquire);                       
-                    if sn == next_sn || next_sn == 0 {
-                        // If we are here, it means we can read the data
-                        read_count = shared_data.read_count.fetch_sub(1, Ordering::AcqRel); 
-                        next_sn = sn + 1;
-                        let mut sum: u32 = 0;
-                        for i in 0..len {
-                            sum += shared_data.data[i] as u32;
-                        }
-                        println!("{} / {} - Consumed buffer of {} bytes with sum {} remaining {} reads ", sn, next_sn, len, sum, read_count -1);
-                        // Just simulate some processing time
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                        
-                        if read_count == 1 {
-                            log::debug!("{} / {} - Last read, resetting length", sn, next_sn);
-                            shared_data.futex.value.store(0, Ordering::SeqCst);
-                            shared_data.futex.wake(1); // Notify the producer that we are done consuming                            
-                            
+                let shared_data: &SharedData = unsafe { &*shm };
+
+                shared_data.sub_count.fetch_add(1, Ordering::AcqRel);
+                let mut read_count = -1;
+                let mut next_sn = 0u64;
+
+                while running.load(Ordering::Acquire) {
+                    log::debug!(
+                        "Waiting for data to be produced -- futex: {}  / {}",
+                        shared_data.futex.value.load(Ordering::SeqCst),
+                        next_sn
+                    );
+                    while shared_data.futex.value.load(Ordering::Acquire) == 0 {
+                        let _ = shared_data.futex.wait(0);
+                    }
+
+                    let len = shared_data.len.load(Ordering::Acquire);
+                    read_count = shared_data.read_count.load(Ordering::Acquire);
+                    let sub_count = shared_data.sub_count.load(Ordering::Acquire);
+                    log::debug!(
+                        "Read count: {}, Sub count: {}, Length: {}",
+                        read_count,
+                        sub_count,
+                        len
+                    );
+
+                    // The only case in which this could happen is if another consumer was added.
+                    if read_count > 0 {
+                        // There is some data to read, if the SN is higher than what we read last time
+                        let sn = shared_data.sn.load(Ordering::Acquire);
+                        if sn == next_sn || next_sn == 0 {
+                            // If we are here, it means we can read the data
+                            read_count = shared_data.read_count.fetch_sub(1, Ordering::AcqRel);
+                            next_sn = sn + 1;
+                            let mut sum: u32 = 0;
+                            for i in 0..len {
+                                sum += shared_data.data[i] as u32;
+                            }
+                            println!(
+                                "{} / {} - Consumed buffer of {} bytes with sum {} remaining {} reads ",
+                                sn,
+                                next_sn,
+                                len,
+                                sum,
+                                read_count - 1
+                            );
+                            // Just simulate some processing time
+                            std::thread::sleep(std::time::Duration::from_millis(500));
+
+                            if read_count == 1 {
+                                log::debug!("{} / {} - Last read, resetting length", sn, next_sn);
+                                shared_data.futex.value.store(0, Ordering::SeqCst);
+                                shared_data.futex.wake(1); // Notify the producer that we are done consuming                            
+                            }
+                        } else {
+                            log::debug!(
+                                "Waiting for new data, current sn: {}, next sn: {}",
+                                sn,
+                                next_sn
+                            );
                         }
                     } else {
-                        log::debug!("Waiting for new data, current sn: {}, next sn: {}", sn, next_sn);                        
+                        log::debug!("Read count is 0, no data to consume");
                     }
-                } else {
-                    log::debug!("Read count is 0, no data to consume");
+                }
+                println!("Polling consumer stopped.");
+                shared_data.sub_count.fetch_sub(1, Ordering::AcqRel);
+                if read_count == 1 {
+                    shared_data.futex.value.store(0, Ordering::SeqCst);
+                    shared_data.futex.wake(1); // Notify the producer that we are done consuming
                 }
             }
-            println!("Polling consumer stopped.");                           
-            shared_data.sub_count.fetch_sub(1, Ordering::AcqRel);
-            if read_count == 1 {                
-                shared_data.futex.value.store(0, Ordering::SeqCst);
-                shared_data.futex.wake(1); // Notify the producer that we are done consuming
-            }
-        }   
+        }
     }
 }
 
 #[cfg(not(target_os = "linux"))]
+mod platform {
+    pub(crate) fn main() {
+        println!("This program only runs on Linux due to futex usage.");
+        std::process::exit(1);
+    }
+}
+
 fn main() {
-    println!("This program only runs on Linux due to futex usage.");
-    std::process::exit(1);
+    platform::main();
 }

--- a/src/await_producer_1n.rs
+++ b/src/await_producer_1n.rs
@@ -1,127 +1,136 @@
 #[cfg(target_os = "linux")]
-use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
+mod platform {
+    use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
 
-#[cfg(target_os = "linux")]
-use rand::random;
-#[cfg(target_os = "linux")]
-use zenoh::{
-    Wait,
-    shm::{AllocAlignment, ShmBuf, ShmProviderBuilder, ZShm},
-};
-
-#[cfg(target_os = "linux")]
-use linux_futex::*;
-
-#[cfg(target_os = "linux")]
-// Shared data
-#[repr(C)]
-pub struct SharedData {
-    pub futex: Futex<Shared>, 
-    pub len: AtomicUsize,
-    pub sn: AtomicU64,
-    pub read_count: AtomicI32, // How many times the data can be consumed
-    pub sub_count: AtomicUsize, // Total number of consumers
-    pub data: [u8; 1024],
-}
-
-#[cfg(target_os = "linux")]
-fn main() {
-    let mut  matrix:  [[i32; 10]; 10] = [[0; 10]; 10];
-    matrix[1][1] = 42; // Example usage of a matrix
-    let z = zenoh::open(zenoh::Config::default())
-        .wait()
-        .expect("Failed to open Zenoh session");
-
-    // get alignment for SharedData type by means of new API
-    let alignment = AllocAlignment::for_type::<SharedData>();
-    let size = std::mem::size_of::<SharedData>();
-
-    // construct provider using default_backend that now supports alignment setting
-    let shm_provider = ShmProviderBuilder::default_backend(size)
-        .with_alignment(alignment)
-        .wait()
-        .unwrap();
-    
-    let buf = shm_provider
-        .alloc(size)
-        .with_alignment(alignment)
-        .wait()
-        .unwrap();
-
-       
-    let shared_data = unsafe { 
-         let ptr = buf.as_ptr() as *const SharedData;
-        &*ptr 
+    use rand::random;
+    use zenoh::{
+        Wait,
+        shm::{AllocAlignment, ShmProviderBuilder, ZShm},
     };
-    shared_data.len
-        .store(0, Ordering::Release);
-    shared_data.sn.store(0, Ordering::Release);
-    shared_data.sub_count.store(0, Ordering::Release);
-    shared_data.read_count.store(0, Ordering::Release);
-    shared_data.futex.value.store(0, Ordering::Release);
 
-    // change the morph of buf to be able to make it's copies
-    let buf: ZShm = buf.into();
+    use linux_futex::*;
 
-    // shallow copy to move in producer thread    
-    let mut buf_in_thread = buf.clone();
-    let tid = std::thread::spawn(move || {
-        
-        let shared_data = unsafe { 
-            let ptr = buf_in_thread.as_mut_unchecked().as_mut_ptr() as *mut SharedData;
-            &mut *ptr 
+    // Shared data
+    #[repr(C)]
+    pub struct SharedData {
+        pub futex: Futex<Shared>,
+        pub len: AtomicUsize,
+        pub sn: AtomicU64,
+        pub read_count: AtomicI32, // How many times the data can be consumed
+        pub sub_count: AtomicUsize, // Total number of consumers
+        pub data: [u8; 1024],
+    }
+
+    pub(crate) fn main() {
+        // get alignment for SharedData type by means of new API
+        let alignment = AllocAlignment::for_type::<SharedData>();
+        let size = std::mem::size_of::<SharedData>();
+
+        // construct provider using default_backend that now supports alignment setting
+        let shm_provider = ShmProviderBuilder::default_backend(size)
+            .with_alignment(alignment)
+            .wait()
+            .unwrap();
+
+        let mut buf = shm_provider
+            .alloc(size)
+            .with_alignment(alignment)
+            .wait()
+            .unwrap();
+
+        let shared_data = unsafe {
+            let ptr = buf.as_mut_ptr() as *mut SharedData;
+            let shared_data = &mut *ptr;
+
+            shared_data.len.store(0, Ordering::Release);
+            shared_data.sn.store(0, Ordering::Release);
+            shared_data.sub_count.store(0, Ordering::Release);
+            shared_data.read_count.store(0, Ordering::Release);
+            shared_data.futex.value.store(0, Ordering::Release);
+            shared_data
         };
 
-        loop {
+        // change the morph of buf to be able to make it's copies
+        let buf: ZShm = buf.into();
+
+        // shallow copy to move in producer thread
+        let buf_in_thread = buf.clone();
+        let tid = std::thread::spawn(move || {
+            let z = zenoh::open(zenoh::Config::default())
+                .wait()
+                .expect("Failed to open Zenoh session");
+
+            let queryable = z
+                .declare_queryable("shm/await/buffer_1n")
+                .wait()
+                .expect("Failed to declare queryable");
+
+            while let Ok(query) = queryable.recv() {
+                query
+                    .reply("shm/await/buffer_1n", buf_in_thread.clone())
+                    .wait()
+                    .expect("Failed to reply to query");
+            }
+        });
+
+        // producer loop
+        while !tid.is_finished() {
             // Wait until the subscriber is ready
-            while shared_data.sub_count.load(Ordering::Acquire) == 0 {                
+            while shared_data.sub_count.load(Ordering::Acquire) == 0 {
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
 
-            log::debug!("Waiting for data to be consumed, futex: {}", shared_data.futex.value.load(Ordering::Acquire));
-            while shared_data.futex.value.load(Ordering::Acquire) == 1     {
+            log::debug!(
+                "Waiting for data to be consumed, futex: {}",
+                shared_data.futex.value.load(Ordering::Acquire)
+            );
+            while shared_data.futex.value.load(Ordering::Acquire) == 1 {
                 let _ = shared_data.futex.wait(1);
             }
             log::debug!("Done Waiting...");
-            
+
             let sn = shared_data.sn.fetch_add(1, Ordering::AcqRel) + 1;
             let mut sum: usize = 0;
-            let len = (512 + random::<u32>() % 513) as usize; // 
+            let len = (512 + random::<u32>() % 513) as usize;
             for i in 0..len {
                 let r: u8 = rand::random();
                 shared_data.data[i] = r;
                 sum += r as usize;
             }
-                                    
-            
-            shared_data.read_count.store(std::cmp::max(shared_data.sub_count.load(Ordering::Acquire), 1) as i32, Ordering::Release);
-            shared_data.len.store(len, Ordering::Release);            
-            println!("{} - Produced buffer of {} bytes with sum of {} for {} subs with read count {}", 
-                sn, len, sum, shared_data.sub_count.load(Ordering::Acquire), shared_data.read_count.load(Ordering::Acquire));
+
+            shared_data.read_count.store(
+                std::cmp::max(shared_data.sub_count.load(Ordering::Acquire), 1) as i32,
+                Ordering::Release,
+            );
+            shared_data.len.store(len, Ordering::Release);
+            println!(
+                "{} - Produced buffer of {} bytes with sum of {} for {} subs with read count {}",
+                sn,
+                len,
+                sum,
+                shared_data.sub_count.load(Ordering::Acquire),
+                shared_data.read_count.load(Ordering::Acquire)
+            );
 
             log::debug!("{} - Data ready, waking up consumers", sn);
             shared_data.futex.value.store(1, Ordering::Release);
-            shared_data.futex.wake(shared_data.sub_count.load(Ordering::Acquire) as i32); // Notify all consumers that data is ready
+            shared_data
+                .futex
+                .wake(shared_data.sub_count.load(Ordering::Acquire) as i32); // Notify all consumers that data is ready
         }
-    });
 
-    let queryable = z
-        .declare_queryable("shm/await/buffer_1n")
-        .wait()
-        .expect("Failed to declare queryable");
-
-    while let Ok(query) = queryable.recv() {
-        query
-            .reply("shm/await/buffer_1n", buf.clone())
-            .wait()
-            .expect("Failed to reply to query");
+        tid.join().expect("Producer thread panicked");
     }
-
-    tid.join().expect("Producer thread panicked");
 }
 
 #[cfg(not(target_os = "linux"))]
+mod platform {
+    pub(crate) fn main() {
+        println!("This program only runs on Linux due to futex usage.");
+        std::process::exit(1);
+    }
+}
+
 fn main() {
-    println!("This program only runs on Linux due to futex usage.");
-    std::process::exit(1);
+    platform::main();
 }

--- a/src/polling_producer.rs
+++ b/src/polling_producer.rs
@@ -1,8 +1,9 @@
-use std::sync::atomic::{AtomicUsize};
+use std::sync::atomic::AtomicUsize;
 
 use rand::random;
 use zenoh::{
-    shm::{ AllocAlignment, ShmBuf, ShmProviderBuilder, ZShm}, Wait
+    Wait,
+    shm::{AllocAlignment, ShmProviderBuilder, ZShm},
 };
 
 // Shared data
@@ -13,10 +14,7 @@ pub struct SharedData {
 }
 
 fn main() {
-    let z = zenoh::open(zenoh::Config::default())
-        .wait()
-        .expect("Failed to open Zenoh session");
-
+    // get alignment for SharedData type by means of new API
     let alignment = AllocAlignment::for_type::<SharedData>();
     let size = std::mem::size_of::<SharedData>();
 
@@ -24,66 +22,68 @@ fn main() {
         .with_alignment(alignment)
         .wait()
         .unwrap();
-    
-    let buf = shm_provider
+
+    let mut buf = shm_provider
         .alloc(size)
         .with_alignment(alignment)
         .wait()
         .unwrap();
 
-    // initialize data        
-    let shared_data = unsafe { 
-         let ptr = buf.as_ptr() as *const SharedData;
-        &*ptr 
+    // initialize data
+    let shared_data = unsafe {
+        let ptr = buf.as_mut_ptr() as *mut SharedData;
+        let shared_data = &mut *ptr;
+
+        shared_data
+            .len
+            .store(0, std::sync::atomic::Ordering::Release);
+        shared_data
     };
-    
-    shared_data.len
-        .store(0, std::sync::atomic::Ordering::Release);
 
     // change the morph of buf to be able to make it's copies
     let buf: ZShm = buf.into();
 
-    // shallow copy to move in producer thread
-    let mut buf_in_thread = buf.clone();
+    // shallow copy to move in responder thread
+    let buf_in_thread = buf.clone();
     let tid = std::thread::spawn(move || {
-        
-        let shared_data = unsafe { 
-            let ptr = buf_in_thread.as_mut_unchecked().as_mut_ptr() as *mut SharedData;
-            &mut *ptr 
-        };
+        let z = zenoh::open(zenoh::Config::default())
+            .wait()
+            .expect("Failed to open Zenoh session");
 
-        loop {
-            let len = shared_data.len.load(std::sync::atomic::Ordering::Acquire);
-            if len == 0 {    
-                let mut sum: usize = 0;
-                let len = (512 + random::<u32>() % 513) as usize; // 
-                for i in 0..len {
-                    let r: u8 = rand::random();
-                    shared_data.data[i] = r;
-                    sum += r as usize;
-                }
+        let queryable = z
+            .declare_queryable("shm/polling/buffer")
+            .wait()
+            .expect("Failed to declare queryable");
 
-                println!("Produced buffer of {len} bytes with sum of {sum}");
-                shared_data.len
-                    .store(len, std::sync::atomic::Ordering::Release);
-            } else {
-                // Wait until the data is consumed
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
+        while let Ok(query) = queryable.recv() {
+            query
+                .reply("shm/polling/buffer", buf_in_thread.clone())
+                .wait()
+                .expect("Failed to reply to query");
         }
     });
 
-    let queryable = z
-        .declare_queryable("shm/polling/buffer")
-        .wait()
-        .expect("Failed to declare queryable");
+    // producer loop
+    while !tid.is_finished() {
+        let len = shared_data.len.load(std::sync::atomic::Ordering::Acquire);
+        if len == 0 {
+            let mut sum: usize = 0;
+            let len = (512 + random::<u32>() % 513) as usize; // 
+            for i in 0..len {
+                let r: u8 = rand::random();
+                shared_data.data[i] = r;
+                sum += r as usize;
+            }
 
-    while let Ok(query) = queryable.recv() {
-        query
-            .reply("shm/polling/buffer", buf.clone())
-            .wait()
-            .expect("Failed to reply to query");
+            println!("Produced buffer of {len} bytes with sum of {sum}");
+            shared_data
+                .len
+                .store(len, std::sync::atomic::Ordering::Release);
+        } else {
+            // Wait until the data is consumed
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
-    tid.join().expect("Producer thread panicked");
+    tid.join().expect("Responder thread panicked");
 }

--- a/src/polling_producer_1n.rs
+++ b/src/polling_producer_1n.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
 use rand::random;
 use zenoh::{
     Wait,
-    shm::{AllocAlignment, ShmBuf, ShmProviderBuilder, ZShm},
+    shm::{AllocAlignment, ShmProviderBuilder, ZShm},
 };
 
 // Shared data
@@ -11,95 +11,96 @@ use zenoh::{
 pub struct SharedData {
     pub len: AtomicUsize,
     pub sn: AtomicU64,
-    pub read_count: AtomicI32, // How many times the data can be consumed
+    pub read_count: AtomicI32,  // How many times the data can be consumed
     pub sub_count: AtomicUsize, // Total number of consumers
     pub data: [u8; 1024],
 }
 
-fn main() {    
-    let z = zenoh::open(zenoh::Config::default())
-        .wait()
-        .expect("Failed to open Zenoh session");
-
+fn main() {
     // get alignment for SharedData type by means of new API
     let alignment = AllocAlignment::for_type::<SharedData>();
     let size = std::mem::size_of::<SharedData>();
 
-    // construct provider using default_backend that now supports alignment setting
     let shm_provider = ShmProviderBuilder::default_backend(size)
         .with_alignment(alignment)
         .wait()
         .unwrap();
-    
-    let buf = shm_provider
+
+    let mut buf = shm_provider
         .alloc(size)
         .with_alignment(alignment)
         .wait()
         .unwrap();
 
-       
-    let shared_data = unsafe { 
-         let ptr = buf.as_ptr() as *const SharedData;
-        &*ptr 
+    // initialize data
+    let shared_data = unsafe {
+        let ptr = buf.as_mut_ptr() as *mut SharedData;
+        let shared_data = &mut *ptr;
+
+        shared_data.len.store(0, Ordering::Release);
+        shared_data.sn.store(0, Ordering::Release);
+        shared_data.sub_count.store(0, Ordering::Release);
+        shared_data.read_count.store(0, Ordering::Release);
+        shared_data
     };
-    shared_data.len
-        .store(0, Ordering::Release);
-    shared_data.sn.store(0, Ordering::Release);
-    shared_data.sub_count.store(0, Ordering::Release);
-    shared_data.read_count.store(0, Ordering::Release);
 
     // change the morph of buf to be able to make it's copies
     let buf: ZShm = buf.into();
 
-    // shallow copy to move in producer thread    
-    let mut buf_in_thread = buf.clone();
+    // shallow copy to move in responder thread
+    let buf_in_thread = buf.clone();
     let tid = std::thread::spawn(move || {
-        
-        let shared_data = unsafe { 
-            let ptr = buf_in_thread.as_mut_unchecked().as_mut_ptr() as *mut SharedData;
-            &mut *ptr 
-        };
+        let z = zenoh::open(zenoh::Config::default())
+            .wait()
+            .expect("Failed to open Zenoh session");
 
-        loop {
-            // Wait until the subscriber is ready
-            while shared_data.sub_count.load(Ordering::Acquire) == 0 {                
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }            
-            let len = shared_data.len.load(Ordering::Acquire);
-            if len == 0 {    
-                shared_data.sn.fetch_add(1, Ordering::AcqRel);
-                let mut sum: usize = 0;
-                let len = (512 + random::<u32>() % 513) as usize; // 
-                for i in 0..len {
-                    let r: u8 = rand::random();
-                    shared_data.data[i] = r;
-                    sum += r as usize;
-                }
+        let queryable = z
+            .declare_queryable("shm/polling/buffer_1n")
+            .wait()
+            .expect("Failed to declare queryable");
 
-                println!("{} - Produced buffer of {} bytes with sum of {} for {} subs", 
-                    shared_data.sn.load(Ordering::Acquire), len, sum, shared_data.sub_count.load(Ordering::Acquire));
-                shared_data.read_count.store(shared_data.sub_count.load(Ordering::Acquire) as i32, Ordering::Release);
-                shared_data.len
-                    .store(len, Ordering::Release);
-                
-            } else {
-                // Wait until the data is consumed
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
+        while let Ok(query) = queryable.recv() {
+            query
+                .reply("shm/polling/buffer_1n", buf_in_thread.clone())
+                .wait()
+                .expect("Failed to reply to query");
         }
     });
 
-    let queryable = z
-        .declare_queryable("shm/polling/buffer_1n")
-        .wait()
-        .expect("Failed to declare queryable");
+    // producer loop
+    while !tid.is_finished() {
+        // Wait until the subscriber is ready
+        while shared_data.sub_count.load(Ordering::Acquire) == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let len = shared_data.len.load(Ordering::Acquire);
+        if len == 0 {
+            shared_data.sn.fetch_add(1, Ordering::AcqRel);
+            let mut sum: usize = 0;
+            let len = (512 + random::<u32>() % 513) as usize; // 
+            for i in 0..len {
+                let r: u8 = rand::random();
+                shared_data.data[i] = r;
+                sum += r as usize;
+            }
 
-    while let Ok(query) = queryable.recv() {
-        query
-            .reply("shm/polling/buffer_1n", buf.clone())
-            .wait()
-            .expect("Failed to reply to query");
+            println!(
+                "{} - Produced buffer of {} bytes with sum of {} for {} subs",
+                shared_data.sn.load(Ordering::Acquire),
+                len,
+                sum,
+                shared_data.sub_count.load(Ordering::Acquire)
+            );
+            shared_data.read_count.store(
+                shared_data.sub_count.load(Ordering::Acquire) as i32,
+                Ordering::Release,
+            );
+            shared_data.len.store(len, Ordering::Release);
+        } else {
+            // Wait until the data is consumed
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
-    tid.join().expect("Producer thread panicked");
+    tid.join().expect("Responder thread panicked");
 }

--- a/src/put_shm.rs
+++ b/src/put_shm.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let msg = "Hello from Zenoh's Shared Memory!";
     let mut buf = provider.alloc(msg.len()).wait().unwrap();
-    buf.as_mut()[..msg.len()].copy_from_slice(msg.as_bytes());
+    buf[..msg.len()].copy_from_slice(msg.as_bytes());
 
     // Make the buf immutable so that we can (shallow) clone it.
     let data: ZShm = buf.into();

--- a/src/put_shm.rs
+++ b/src/put_shm.rs
@@ -7,20 +7,19 @@ fn main() {
         .wait()
         .expect("Failed to open Zenoh session");
 
-    let provider = ShmProviderBuilder::default_backend(64*1024)
+    let provider = ShmProviderBuilder::default_backend(64 * 1024)
         .wait()
         .expect("Failed to create SHM provider");
 
-    let mut buf = provider.alloc(256).wait().unwrap();
-    let data_mut: &mut [u8] = &mut buf;
     let msg = "Hello from Zenoh's Shared Memory!";
-    data_mut[..msg.len()].copy_from_slice(msg.as_bytes());
-    
+    let mut buf = provider.alloc(msg.len()).wait().unwrap();
+    buf.as_mut()[..msg.len()].copy_from_slice(msg.as_bytes());
+
     // Make the buf immutable so that we can (shallow) clone it.
     let data: ZShm = buf.into();
 
-    loop {        
-        z.put("zenoh/shm/buffer",data.clone())
+    loop {
+        z.put("zenoh/shm/buffer", data.clone())
             .wait()
             .expect("Failed to put SHM buffer");
         print!(".");

--- a/src/sub_shm.rs
+++ b/src/sub_shm.rs
@@ -11,10 +11,10 @@ fn main() {
     while let Ok(s) = sub.recv() {
         let buf = s.payload();
         
-        let is_shm = if buf.as_shm().is_none() { false } else { true };            
+        let is_shm = buf.as_shm().is_some();            
 
         buf.try_to_string()
-            .map(|s| println!("Received (SHM: {}): {}",is_shm, s))
+            .map(|s| println!("Received (SHM: {is_shm}): {s}"))
             .unwrap_or_else(|_| println!("Received non-string payload"));                       
     }
 }


### PR DESCRIPTION
Reorganize producer-consumer examples:
- move platform code to separate modules (to avoid many #[cfg(target_os = "linux")])
- reorganize threads in producers so that the logic is correct and more fail-safe
- small improvements